### PR TITLE
Fix font size units

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -13,13 +13,13 @@ body {
     margin: 40px auto;
     max-width: 768px;
     line-height: 1.6;
-    font-size: 20px;
+    font-size: 1.25rem;
     color: #444;
     padding: 0 10px;
 }
 
 pre {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 h1, h2, h3 {


### PR DESCRIPTION
Changes font size units from `px` to `rem`. This is equivalent for most users but respects the font size changes of users who explicitly modify their browser's font size.

Note that `1rem` by default is `16px`.

- 16px => 1rem
- 20px => 1.25rem