### PR TITLE
Fix pre wrap

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -19,6 +19,7 @@ body {
 }
 
 pre {
+    overflow-x: auto;
     font-size: 16px;
 }
 


### PR DESCRIPTION
Fixes the `pre` element not wrapping. This makes reading on mobile not have side scroll or zoom issues.